### PR TITLE
Added three new behaviours

### DIFF
--- a/src/Cimbalino.Toolkit (WP8)/Behaviors/EnterKeyBehaviour.cs
+++ b/src/Cimbalino.Toolkit (WP8)/Behaviors/EnterKeyBehaviour.cs
@@ -1,0 +1,81 @@
+﻿#if !WINDOWS_PHONE
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Input;
+#else
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Interactivity;
+using KeyRoutedEventArgs = System.Windows.Input.KeyEventArgs;
+using VirtualKey = System.Windows.Input.Key;
+#endif
+
+namespace Cimbalino.Toolkit.Behaviors
+{
+    /// <summary>
+    /// Provides a behavior for handling the Enter key press to move to the next control or to
+    /// execute a command.
+    /// </summary>
+    public class EnterKeyHandler : Behavior<Control>
+    {
+        /// <summary>
+        /// Identifies the <see cref="P:CommandString"/> attached property.
+        /// </summary>
+        public static readonly DependencyProperty CommandStringProperty =
+            DependencyProperty.Register(
+                "Command",
+                typeof(ICommand),
+                typeof(EnterKeyHandler),
+                null);
+        
+        /// <summary>
+        /// Gets or sets the name of the command to execute.
+        /// </summary>
+        /// <value>The name of the command to execute.</value>
+        public ICommand Command
+        {
+            get { return (ICommand)GetValue(CommandStringProperty); }
+            set { SetValue(CommandStringProperty, value); }
+        }
+
+        /// <summary>
+        /// Called after the behavior is attached to an AssociatedObject.
+        /// </summary>
+        /// <remarks>Override this to hook up functionality to the AssociatedObject.</remarks>
+        protected override void OnAttached()
+        {
+            base.OnAttached();
+
+            if (null != AssociatedObject)
+            {
+                AssociatedObject.KeyDown += Control_KeyDown;
+            }
+        }
+
+        /// <summary>
+        /// Called when the behavior is being detached from its AssociatedObject, but before it has actually occurred.
+        /// </summary>
+        /// <remarks>Override this to unhook functionality from the AssociatedObject.</remarks>
+        protected override void OnDetaching()
+        {
+            base.OnDetaching();
+
+            if (null != AssociatedObject)
+            {
+                AssociatedObject.KeyDown -= Control_KeyDown;
+            }
+        }
+
+        private void Control_KeyDown(object sender, KeyRoutedEventArgs args)
+        {
+            if ((VirtualKey.Enter == args.Key))
+            {
+                if (Command != null)
+                {
+                    Command.Execute(null);
+                }
+            }
+        }
+    }
+}

--- a/src/Cimbalino.Toolkit (WP8)/Behaviors/UpdatePasswordBindingOnPropertyChanged.cs
+++ b/src/Cimbalino.Toolkit (WP8)/Behaviors/UpdatePasswordBindingOnPropertyChanged.cs
@@ -6,11 +6,23 @@ using System.Windows.Input;
 
 namespace Cimbalino.Toolkit.Behaviors
 {
+    /// <summary>
+    /// Updates the Password binding when the text changes rather than when the PasswordBox loses focus
+    /// </summary>
     public class UpdatePasswordBindingOnPropertyChanged : Behavior<PasswordBox>
     {
+        /// <summary>
+        /// The enter hit command property
+        /// </summary>
         public static readonly DependencyProperty EnterHitCommandProperty =
             DependencyProperty.Register("EnterHitCommand", typeof (ICommand), typeof (UpdateTextBindingOnPropertyChanged), new PropertyMetadata(default(ICommand)));
 
+        /// <summary>
+        /// Gets or sets the enter hit command.
+        /// </summary>
+        /// <value>
+        /// The enter hit command.
+        /// </value>
         public ICommand EnterHitCommand
         {
             get { return (ICommand) GetValue(EnterHitCommandProperty); }
@@ -21,6 +33,12 @@ namespace Cimbalino.Toolkit.Behaviors
         private BindingExpression _expression;
 
         // Methods
+        /// <summary>
+        /// Called after the behavior is attached to an AssociatedObject.
+        /// </summary>
+        /// <remarks>
+        /// Override this to hook up functionality to the AssociatedObject.
+        /// </remarks>
         protected override void OnAttached()
         {
             base.OnAttached();
@@ -29,6 +47,11 @@ namespace Cimbalino.Toolkit.Behaviors
             AssociatedObject.KeyUp += OnKeyUp;
         }
 
+        /// <summary>
+        /// Called when [key up].
+        /// </summary>
+        /// <param name="sender">The sender.</param>
+        /// <param name="keyEventArgs">The <see cref="KeyEventArgs"/> instance containing the event data.</param>
         private void OnKeyUp(object sender, KeyEventArgs keyEventArgs)
         {
             if (keyEventArgs.Key != Key.Enter) return;
@@ -38,6 +61,12 @@ namespace Cimbalino.Toolkit.Behaviors
             }
         }
 
+        /// <summary>
+        /// Called when the behavior is being detached from its AssociatedObject, but before it has actually occurred.
+        /// </summary>
+        /// <remarks>
+        /// Override this to unhook functionality from the AssociatedObject.
+        /// </remarks>
         protected override void OnDetaching()
         {
             base.OnDetaching();
@@ -45,6 +74,11 @@ namespace Cimbalino.Toolkit.Behaviors
             _expression = null;
         }
 
+        /// <summary>
+        /// Called when [text changed].
+        /// </summary>
+        /// <param name="sender">The sender.</param>
+        /// <param name="args">The <see cref="RoutedEventArgs"/> instance containing the event data.</param>
         private void OnTextChanged(object sender, RoutedEventArgs args)
         {
             _expression.UpdateSource();

--- a/src/Cimbalino.Toolkit (WP8)/Behaviors/UpdatePasswordBindingOnPropertyChanged.cs
+++ b/src/Cimbalino.Toolkit (WP8)/Behaviors/UpdatePasswordBindingOnPropertyChanged.cs
@@ -1,0 +1,53 @@
+﻿using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Interactivity;
+using System.Windows.Input;
+
+namespace Cimbalino.Toolkit.Behaviors
+{
+    public class UpdatePasswordBindingOnPropertyChanged : Behavior<PasswordBox>
+    {
+        public static readonly DependencyProperty EnterHitCommandProperty =
+            DependencyProperty.Register("EnterHitCommand", typeof (ICommand), typeof (UpdateTextBindingOnPropertyChanged), new PropertyMetadata(default(ICommand)));
+
+        public ICommand EnterHitCommand
+        {
+            get { return (ICommand) GetValue(EnterHitCommandProperty); }
+            set { SetValue(EnterHitCommandProperty, value); }
+        }
+
+        // Fields
+        private BindingExpression _expression;
+
+        // Methods
+        protected override void OnAttached()
+        {
+            base.OnAttached();
+            _expression = AssociatedObject.GetBindingExpression(TextBox.TextProperty);
+            AssociatedObject.PasswordChanged += OnTextChanged;
+            AssociatedObject.KeyUp += OnKeyUp;
+        }
+
+        private void OnKeyUp(object sender, KeyEventArgs keyEventArgs)
+        {
+            if (keyEventArgs.Key != Key.Enter) return;
+            if (EnterHitCommand != null && EnterHitCommand.CanExecute(null))
+            {
+                EnterHitCommand.Execute(null);
+            }
+        }
+
+        protected override void OnDetaching()
+        {
+            base.OnDetaching();
+            AssociatedObject.PasswordChanged -= OnTextChanged;
+            _expression = null;
+        }
+
+        private void OnTextChanged(object sender, RoutedEventArgs args)
+        {
+            _expression.UpdateSource();
+        }
+    }
+}

--- a/src/Cimbalino.Toolkit (WP8)/Behaviors/UpdateTextBindingOnPropertyChanged.cs
+++ b/src/Cimbalino.Toolkit (WP8)/Behaviors/UpdateTextBindingOnPropertyChanged.cs
@@ -16,11 +16,23 @@ using System.Windows.Input;
 
 namespace Cimbalino.Toolkit.Behaviors
 {
+    /// <summary>
+    /// Updates the Text binding when the text changes rather than when the TextBox loses focus
+    /// </summary>
     public class UpdateTextBindingOnPropertyChanged : Behavior<TextBox>
     {
+        /// <summary>
+        /// The enter hit command property
+        /// </summary>
         public static readonly DependencyProperty EnterHitCommandProperty =
             DependencyProperty.Register("EnterHitCommand", typeof (ICommand), typeof (UpdateTextBindingOnPropertyChanged), new PropertyMetadata(default(ICommand)));
 
+        /// <summary>
+        /// Gets or sets the enter hit command.
+        /// </summary>
+        /// <value>
+        /// The enter hit command.
+        /// </value>
         public ICommand EnterHitCommand
         {
             get { return (ICommand) GetValue(EnterHitCommandProperty); }
@@ -31,6 +43,12 @@ namespace Cimbalino.Toolkit.Behaviors
         private BindingExpression _expression;
 
         // Methods
+        /// <summary>
+        /// Called after the behavior is attached to an AssociatedObject.
+        /// </summary>
+        /// <remarks>
+        /// Override this to hook up functionality to the AssociatedObject.
+        /// </remarks>
         protected override void OnAttached()
         {
             base.OnAttached();
@@ -38,6 +56,11 @@ namespace Cimbalino.Toolkit.Behaviors
             AssociatedObject.TextChanged += OnTextChanged;
             AssociatedObject.KeyUp += OnKeyUp;
         }
+        /// <summary>
+        /// Called when [key up].
+        /// </summary>
+        /// <param name="sender">The sender.</param>
+        /// <param name="keyEventArgs">The <see cref="KeyRoutedEventArgs"/> instance containing the event data.</param>
         private void OnKeyUp(object sender, KeyRoutedEventArgs keyEventArgs)
         {
             if (keyEventArgs.Key != VirtualKey.Enter) return;
@@ -47,6 +70,12 @@ namespace Cimbalino.Toolkit.Behaviors
             }
         }
 
+        /// <summary>
+        /// Called when the behavior is being detached from its AssociatedObject, but before it has actually occurred.
+        /// </summary>
+        /// <remarks>
+        /// Override this to unhook functionality from the AssociatedObject.
+        /// </remarks>
         protected override void OnDetaching()
         {
             base.OnDetaching();
@@ -54,6 +83,11 @@ namespace Cimbalino.Toolkit.Behaviors
             _expression = null;
         }
 
+        /// <summary>
+        /// Called when [text changed].
+        /// </summary>
+        /// <param name="sender">The sender.</param>
+        /// <param name="args">The <see cref="TextChangedEventArgs"/> instance containing the event data.</param>
         private void OnTextChanged(object sender, TextChangedEventArgs args)
         {
             _expression.UpdateSource();

--- a/src/Cimbalino.Toolkit (WP8)/Behaviors/UpdateTextBindingOnPropertyChanged.cs
+++ b/src/Cimbalino.Toolkit (WP8)/Behaviors/UpdateTextBindingOnPropertyChanged.cs
@@ -1,0 +1,62 @@
+﻿#if !WINDOWS_PHONE
+using Windows.System;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+#else
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Interactivity;
+using KeyRoutedEventArgs = System.Windows.Input.KeyEventArgs;
+using VirtualKey = System.Windows.Input.Key;
+#endif
+using System.Windows.Input;
+
+namespace Cimbalino.Toolkit.Behaviors
+{
+    public class UpdateTextBindingOnPropertyChanged : Behavior<TextBox>
+    {
+        public static readonly DependencyProperty EnterHitCommandProperty =
+            DependencyProperty.Register("EnterHitCommand", typeof (ICommand), typeof (UpdateTextBindingOnPropertyChanged), new PropertyMetadata(default(ICommand)));
+
+        public ICommand EnterHitCommand
+        {
+            get { return (ICommand) GetValue(EnterHitCommandProperty); }
+            set { SetValue(EnterHitCommandProperty, value); }
+        }
+
+        // Fields
+        private BindingExpression _expression;
+
+        // Methods
+        protected override void OnAttached()
+        {
+            base.OnAttached();
+            _expression = AssociatedObject.GetBindingExpression(TextBox.TextProperty);
+            AssociatedObject.TextChanged += OnTextChanged;
+            AssociatedObject.KeyUp += OnKeyUp;
+        }
+        private void OnKeyUp(object sender, KeyRoutedEventArgs keyEventArgs)
+        {
+            if (keyEventArgs.Key != VirtualKey.Enter) return;
+            if (EnterHitCommand != null && EnterHitCommand.CanExecute(null))
+            {
+                EnterHitCommand.Execute(null);
+            }
+        }
+
+        protected override void OnDetaching()
+        {
+            base.OnDetaching();
+            AssociatedObject.TextChanged -= OnTextChanged;
+            _expression = null;
+        }
+
+        private void OnTextChanged(object sender, TextChangedEventArgs args)
+        {
+            _expression.UpdateSource();
+        }
+    }
+}

--- a/src/Cimbalino.Toolkit (WP8)/Cimbalino.Toolkit (WP8).csproj
+++ b/src/Cimbalino.Toolkit (WP8)/Cimbalino.Toolkit (WP8).csproj
@@ -96,11 +96,14 @@
     <Compile Include="Behaviors\ApplicationBarMenuItem.cs" />
     <Compile Include="Behaviors\ApplicationBarMenuItemCollection.cs" />
     <Compile Include="Behaviors\AutoFocusBehavior.cs" />
+    <Compile Include="Behaviors\EnterKeyBehaviour.cs" />
     <Compile Include="Behaviors\MultiApplicationBarBehavior.cs" />
     <Compile Include="Behaviors\MultiBindingBehavior.cs" />
     <Compile Include="Behaviors\MultiBindingItem.cs" />
     <Compile Include="Behaviors\MultiBindingItemCollection.cs" />
     <Compile Include="Behaviors\ScreenCaptureBehavior.cs" />
+    <Compile Include="Behaviors\UpdatePasswordBindingOnPropertyChanged.cs" />
+    <Compile Include="Behaviors\UpdateTextBindingOnPropertyChanged.cs" />
     <Compile Include="Converters\BooleanToBrushConverter.cs" />
     <Compile Include="Converters\BooleanToIntConverter.cs" />
     <Compile Include="Converters\BooleanToStringConverter.cs" />

--- a/src/Cimbalino.Toolkit (WPA81)/Cimbalino.Toolkit (WPA81).csproj
+++ b/src/Cimbalino.Toolkit (WPA81)/Cimbalino.Toolkit (WPA81).csproj
@@ -95,6 +95,9 @@
     <Compile Include="..\Cimbalino.Toolkit %28WP8%29\Behaviors\AutoFocusBehavior.cs">
       <Link>Behaviors\AutoFocusBehavior.cs</Link>
     </Compile>
+    <Compile Include="..\Cimbalino.Toolkit %28WP8%29\Behaviors\EnterKeyBehaviour.cs">
+      <Link>Behaviors\EnterKeyBehaviour.cs</Link>
+    </Compile>
     <Compile Include="..\Cimbalino.Toolkit %28WP8%29\Behaviors\MultiBindingBehavior.cs">
       <Link>Behaviors\MultiBindingBehavior.cs</Link>
     </Compile>
@@ -106,6 +109,9 @@
     </Compile>
     <Compile Include="..\Cimbalino.Toolkit %28WP8%29\Behaviors\ScreenCaptureBehavior.cs">
       <Link>Behaviors\ScreenCaptureBehavior.cs</Link>
+    </Compile>
+    <Compile Include="..\Cimbalino.Toolkit %28WP8%29\Behaviors\UpdateTextBindingOnPropertyChanged.cs">
+      <Link>Behaviors\UpdateTextBindingOnPropertyChanged.cs</Link>
     </Compile>
     <Compile Include="..\Cimbalino.Toolkit %28WP8%29\Converters\BooleanToBrushConverter.cs">
       <Link>Converters\BooleanToBrushConverter.cs</Link>

--- a/src/Cimbalino.Toolkit (Win81)/Cimbalino.Toolkit (Win81).csproj
+++ b/src/Cimbalino.Toolkit (Win81)/Cimbalino.Toolkit (Win81).csproj
@@ -117,6 +117,9 @@
     <Compile Include="..\Cimbalino.Toolkit %28WP8%29\Behaviors\AutoFocusBehavior.cs">
       <Link>Behaviors\AutoFocusBehavior.cs</Link>
     </Compile>
+    <Compile Include="..\Cimbalino.Toolkit %28WP8%29\Behaviors\EnterKeyBehaviour.cs">
+      <Link>Behaviors\EnterKeyBehaviour.cs</Link>
+    </Compile>
     <Compile Include="..\Cimbalino.Toolkit %28WP8%29\Behaviors\MultiBindingBehavior.cs">
       <Link>Behaviors\MultiBindingBehavior.cs</Link>
     </Compile>
@@ -128,6 +131,9 @@
     </Compile>
     <Compile Include="..\Cimbalino.Toolkit %28WP8%29\Behaviors\ScreenCaptureBehavior.cs">
       <Link>Behaviors\ScreenCaptureBehavior.cs</Link>
+    </Compile>
+    <Compile Include="..\Cimbalino.Toolkit %28WP8%29\Behaviors\UpdateTextBindingOnPropertyChanged.cs">
+      <Link>Behaviors\UpdateTextBindingOnPropertyChanged.cs</Link>
     </Compile>
     <Compile Include="..\Cimbalino.Toolkit %28WP8%29\Converters\BooleanToBrushConverter.cs">
       <Link>Converters\BooleanToBrushConverter.cs</Link>


### PR DESCRIPTION
1) UpdateTextBindingOnPropertyChanged - for all platforms, allows a text
binding to update when text changed rather than when focus changed.
Supports an EnterKey Command
2) UpdatePasswordBindingOnPropertyChanged - for WP8 only, RT platforms
the Password updates correctly
3) EnterKeyHandler - All platforms, supports adding an EnterKey Command
to all Controls