### PR TITLE
Fixkeyboardforwp8Core

### DIFF
--- a/src/Cimbalino.Toolkit (WP8)/Cimbalino.Toolkit (WP8).csproj
+++ b/src/Cimbalino.Toolkit (WP8)/Cimbalino.Toolkit (WP8).csproj
@@ -123,6 +123,7 @@
     <Compile Include="Helpers\NamescopeBinding.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Services\DeviceSettingsService.cs" />
+    <Compile Include="Services\DeviceStatusServiceWithKeyboard.cs" />
     <Compile Include="Services\DisplayPropertiesService.cs" />
     <Compile Include="Services\EmailComposeService.cs" />
     <Compile Include="Services\LauncherService.cs" />

--- a/src/Cimbalino.Toolkit (WP8)/Services/DeviceStatusServiceWithKeyboard.cs
+++ b/src/Cimbalino.Toolkit (WP8)/Services/DeviceStatusServiceWithKeyboard.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.Phone.Info;
+
+namespace Cimbalino.Toolkit.Services
+{
+    public class DeviceStatusServiceWithKeyboard : DeviceStatusService
+    {
+        /// <summary>
+        /// Gets a value indicating whether the user has deployed the physical hardware keyboard of the device.
+        /// </summary>
+        /// <value>true if the keyboard is deployed; otherwise, false.</value>
+        public virtual bool IsKeyboardDeployed
+        {
+            get
+            {
+                return DeviceStatus.IsKeyboardDeployed;
+            }
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the device contains a physical hardware keyboard.
+        /// </summary>
+        /// <value>
+        /// true if the device contains a physical hardware keyboard; otherwise, false.
+        /// </value>
+        public virtual bool IsKeyboardPresent
+        {
+            get
+            {
+                return DeviceStatus.IsKeyboardPresent;
+            }
+        }
+    }
+}

--- a/src/Cimbalino.Toolkit.Core (WP8)/Services/DeviceStatusService.cs
+++ b/src/Cimbalino.Toolkit.Core (WP8)/Services/DeviceStatusService.cs
@@ -142,7 +142,7 @@ namespace Cimbalino.Toolkit.Services
         {
             get
             {
-                return DeviceStatus.IsKeyboardDeployed;
+                throw new NotSupportedException("Please use DeviceStatusServiceWithKeyboard for this property.");
             }
         }
 
@@ -156,7 +156,7 @@ namespace Cimbalino.Toolkit.Services
         {
             get
             {
-                return DeviceStatus.IsKeyboardPresent;
+                throw new NotSupportedException("Please use DeviceStatusServiceWithKeyboard for this property.");
             }
         }
 


### PR DESCRIPTION
You can't access keyboard APIs from a background agent, which is where you'd want to be using the Core project. Created a new service in the main project that allows you to access keyboard APIs