### PR TITLE
Make sure to subscribe to HardwareButton.BackKeyPressed upon constructio...

### DIFF
--- a/src/Cimbalino.Toolkit (WPA81)/Services/NavigationService.cs
+++ b/src/Cimbalino.Toolkit (WPA81)/Services/NavigationService.cs
@@ -46,6 +46,43 @@ namespace Cimbalino.Toolkit.Services
         /// </summary>
 #if WINDOWS_PHONE_APP
         public event EventHandler<NavigationServiceBackKeyPressedEventArgs> BackKeyPressed;
+
+         public NavigationService()
+        {
+            HardwareButtons.BackPressed += (s, e) =>
+            {
+                var eventArgs = new NavigationServiceBackKeyPressedEventArgs();
+
+                RaiseBackKeyPressed(eventArgs);
+
+                switch (eventArgs.Behavior)
+                {
+                    case NavigationServiceBackKeyPressedBehavior.GoBack:
+                        if (EnsureMainFrame() && _mainFrame.CanGoBack)
+                        {
+                            _mainFrame.GoBack();
+
+                            e.Handled = true;
+                        }
+                        break;
+
+                    case NavigationServiceBackKeyPressedBehavior.HideApp:
+                        break;
+
+                    case NavigationServiceBackKeyPressedBehavior.ExitApp:
+                        e.Handled = true;
+                        Application.Current.Exit();
+                        break;
+
+                    case NavigationServiceBackKeyPressedBehavior.DoNothing:
+                        e.Handled = true;
+                        break;
+
+                    default:
+                        throw new ArgumentOutOfRangeException();
+                }
+            };
+        }
 #else
         public event EventHandler<NavigationServiceBackKeyPressedEventArgs> BackKeyPressed
         {
@@ -244,42 +281,6 @@ namespace Cimbalino.Toolkit.Services
 
                     RaiseNavigated(null);
                 };
-
-#if WINDOWS_PHONE_APP
-                HardwareButtons.BackPressed += (s, e) =>
-                {
-                    var eventArgs = new NavigationServiceBackKeyPressedEventArgs();
-
-                    RaiseBackKeyPressed(eventArgs);
-
-                    switch (eventArgs.Behavior)
-                    {
-                        case NavigationServiceBackKeyPressedBehavior.GoBack:
-                            if (_mainFrame.CanGoBack)
-                            {
-                                _mainFrame.GoBack();
-
-                                e.Handled = true;
-                            }
-                            break;
-
-                        case NavigationServiceBackKeyPressedBehavior.HideApp:
-                            break;
-
-                        case NavigationServiceBackKeyPressedBehavior.ExitApp:
-                            e.Handled = true;
-                            Application.Current.Exit();
-                            break;
-
-                        case NavigationServiceBackKeyPressedBehavior.DoNothing:
-                            e.Handled = true;
-                            break;
-
-                        default:
-                            throw new ArgumentOutOfRangeException();
-                    }
-                };
-#endif
 
                 return true;
             }


### PR DESCRIPTION
...n.

Fixes bug where if no Forward navigation had occured yet, typically upon app restore, Back-key presses would be missed since EnsureMainFrame hadn't been called and therefore HardwareButton event wasn't subscribed to, hence app would just exit