### PR TITLE
Ensure we're catering for nulls

### DIFF
--- a/src/Cimbalino.Toolkit (WPA81)/Services/NavigationService.cs
+++ b/src/Cimbalino.Toolkit (WPA81)/Services/NavigationService.cs
@@ -329,7 +329,7 @@ namespace Cimbalino.Toolkit.Services
             switch (eventArgs.Behavior)
             {
                 case NavigationServiceBackKeyPressedBehavior.GoBack:
-                    if (_mainFrame.CanGoBack)
+                    if (_mainFrame?.CanGoBack ?? false)
                     {
                         _mainFrame.GoBack();
                         handled = true;
@@ -339,7 +339,7 @@ namespace Cimbalino.Toolkit.Services
                     break;
                 case NavigationServiceBackKeyPressedBehavior.ExitApp:
                     handled = true;
-                    Application.Current.Exit();
+                    Application.Current?.Exit();
                     break;
                 case NavigationServiceBackKeyPressedBehavior.DoNothing:
                     handled = true;


### PR DESCRIPTION
This is mainly if _mainFrame is null or Application.Current is null
(when exiting the app)