### PR TITLE
Extend EnterKeyBehavior with the choice to handle already handled KeyDown events.

### DIFF
--- a/src/Cimbalino.Toolkit (WP8)/Behaviors/EnterKeyBehavior.cs
+++ b/src/Cimbalino.Toolkit (WP8)/Behaviors/EnterKeyBehavior.cs
@@ -82,6 +82,23 @@ namespace Cimbalino.Toolkit.Behaviors
         public static readonly DependencyProperty CommandParameterProperty =
             DependencyProperty.Register(nameof(CommandParameter), typeof(object), typeof(EnterKeyBehavior), null);
 
+
+        /// <summary>
+        /// Enable or disable handling of already handled KeyDown events. Default is false.
+        /// </summary>
+        public bool AllowHandled
+        {
+            get { return (bool)GetValue(AllowHandledProperty); }
+            set { SetValue(AllowHandledProperty, value); }
+        }
+
+        /// <summary>
+        /// Identifier for the <see cref="AllowHandled"/> dependency property 
+        /// </summary>
+        public static readonly DependencyProperty AllowHandledProperty =
+            DependencyProperty.Register("AllowHandled", typeof(bool), typeof(EnterKeyBehavior), new PropertyMetadata(false));
+
+
         /// <summary>
         /// Called after the behavior is attached to an AssociatedObject.
         /// </summary>
@@ -90,8 +107,7 @@ namespace Cimbalino.Toolkit.Behaviors
         /// </remarks>
         protected override void OnAttached()
         {
-            AssociatedObject.KeyDown += AssociatedObjectKeyDown;
-
+            AssociatedObject.AddHandler(UIElement.KeyDownEvent, new KeyEventHandler(AssociatedObjectKeyDown), AllowHandled);
             base.OnAttached();
         }
 
@@ -103,8 +119,7 @@ namespace Cimbalino.Toolkit.Behaviors
         /// </remarks>
         protected override void OnDetaching()
         {
-            AssociatedObject.KeyDown -= AssociatedObjectKeyDown;
-
+            AssociatedObject.RemoveHandler(UIElement.KeyDownEvent, new KeyEventHandler(AssociatedObjectKeyDown));
             base.OnDetaching();
         }
 


### PR DESCRIPTION
I tried using the EnterKeyBehavior on a ListView in a UWP app and it was not working. The reason for this is described in the following stackoverflow question.

[How can I override or act on KeyDown: Space or Enter for ListView in UWP?](https://stackoverflow.com/questions/37376510/how-can-i-override-or-act-on-keydown-space-or-enter-for-listview-in-uwp)

The KeyDown event is sometimes handled internally by some controls (e.g. a ListView) and therefore doesn't bubble up to reach the handler in the behavior.

The changes in this PR allow the user a choice whether he/she wants to handle already handled events or not.

If you have any comments or concerns about the PR please let me know so that I may address them.

Thanks again for a great toolkit :)  
